### PR TITLE
Add ability to set per-extension query and info for pages picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,8 @@ You have access to the very same options as [the textarea field](https://getkirb
 | Option | Type   | Required | Default                | Description                                        |
 |:-------|:-------|:---------|:-----------------------|:---------------------------------------------------|
 | font   | string | `false`  | `monospace`            | Sets the font family (`sans-serif` or `monospace`) |
-| query  | Object | `false`  | [see below](#34-query) | Sets a custom query for the page selector dialog   |
+| query  | Object | `false`  | [see below](#35-query) | Sets a custom query for the page selector dialog   |
+| info   | Object | `false`  | [see below](#36-query) | Sets a custom info for the page selector dialog    |
 | size   | String | `false`  | `small`                | Sets the empty height of the Markdown field        |
 
 ### 3.2. Font settings
@@ -211,7 +212,17 @@ query:
   pagelink: kirby.page('my-page').children
 ```
 
-### 3.6. Size
+### 3.6. Info
+
+You can add info text for the options shown in the Pagelink dialog, by setting `pagelink` info.
+
+```yaml
+info:
+  pagelink: "{{ page.tags }}"
+```
+
+
+### 3.7. Size
 
 You can define the height of the field when empty. Default is `two-lines`, which mimics the textarea's default empty height.
 

--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Enhanced, extensible Markdown field for Kirby CMS. Now available in version 2!
       - [Inline Formats](#inline-formats)
       - [Other](#other)
     - [URLs](#urls)
-    - [3.5. Query](#35-query)
+    - [3.5. Pages](#35-pages)
     - [3.6. Size](#36-size)
   - [4. Extension API](#4-extension-api)
+    - [4.1 Custom options for pages, files, and uploads](#41-custom-options-for-pages-files-and-uploads)
   - [5. Development](#5-development)
   - [7. Migrating from Version 1](#7-migrating-from-version-1)
   - [8. Known Issues](#8-known-issues)
@@ -81,8 +82,7 @@ You have access to the very same options as [the textarea field](https://getkirb
 | Option | Type   | Required | Default                | Description                                        |
 |:-------|:-------|:---------|:-----------------------|:---------------------------------------------------|
 | font   | string | `false`  | `monospace`            | Sets the font family (`sans-serif` or `monospace`) |
-| query  | Object | `false`  | [see below](#35-query) | Sets a custom query for the page selector dialog   |
-| info   | Object | `false`  | [see below](#36-query) | Sets a custom info for the page selector dialog    |
+| pages  | Object | `false`  | [see below](#35-pages) | Sets a custom query for the page selector dialog   |
 | size   | String | `false`  | `small`                | Sets the empty height of the Markdown field        |
 
 ### 3.2. Font settings
@@ -203,26 +203,24 @@ buttons:
 
 - When you select some text and paste a URL, it will automatically create a link tag and use the current selection as link text.
 
-### 3.5. Query
+### 3.5. Pages
 
-You can limit the options shown in the Pagelink dialog, by setting a `pagelink` query (if unset, you'll be able to browse the entire website tree)
-
-```yaml
-query:
-  pagelink: kirby.page('my-page').children
-```
-
-### 3.6. Info
-
-You can add info text for the options shown in the Pagelink dialog, by setting `pagelink` info.
+You can limit the options shown in the Pagelink dialog, by setting the `pages` option with a query (if unset, you'll be able to browse the entire website tree)
 
 ```yaml
-info:
-  pagelink: "{{ page.tags }}"
+pages: kirby.page('my-page').children
 ```
 
+You can also set the `pages` option to an object with other properties from [the pages field](https://getkirby.com/docs/reference/panel/fields/pages) such as info and text
 
-### 3.7. Size
+```yaml
+pages:
+  query: kirby.page('my-page').children
+  info: "{{ page.tags }}"
+  text: "{{ page.title.upper }}"
+```
+
+### 3.6. Size
 
 You can define the height of the field when empty. Default is `two-lines`, which mimics the textarea's default empty height.
 
@@ -262,6 +260,34 @@ There are two types of extensions, which allow you to extend the editor to adjus
 - **Custom buttons:** You can define your own buttons, which can be added to the editor toolbar. Buttons can define keyboard shortcuts, displays dropdowns and even show a popup.
 - **Custom extensions:** You can define your own editor extensions. An example can be found in the `extension-examples/indent-with-tab` folder.
 - **Custom highlights:** You can define regex-based custom highlights, which allow you to highlight any text, such as markup for custom syntax (e.g. global text snippets or Wiki-style links)
+
+### 4.1 Custom options for pages, files, and uploads
+
+Your extension can use a special endpoint to extend the base options for pages, files, and uploads with parameters set in the button configuration. See an example in the `extension-examples/custom-pagelink` folder.
+
+
+```js
+// special routes to read options from the button configuration
+this.input.endpoints.field + "/myextension/pages"
+this.input.endpoints.field + "/myextension/uploads"
+this.input.endpoints.field + "/myextension/files"
+```
+
+The end user can configure options for your extension as part of the button configuration:
+
+```yaml
+text:
+  type: markdown
+  files:
+    […]
+  pages:
+    […]
+  buttons:
+    myextension:
+      pages:
+        query: site.index
+        info: "{{ page.tags }}"
+```
 
 ## 5. Development
 

--- a/extension-examples/custom-pagelink/index.js
+++ b/extension-examples/custom-pagelink/index.js
@@ -1,0 +1,81 @@
+(function() {
+
+  // Ensure, that the global `markdownEditorButtons` variable exists, otherwise
+  // declare it. It is just a plain array, that gets read whenever the field is use.
+  window.markdownEditorButtons = window.markdownEditorButtons || [];
+
+  // Pass the plugin definition to the buttons array
+  window.markdownEditorButtons.push({
+    /**
+     * This button is a custom pagelink page picker, whose query and info are derived from
+     * the field config in your blueprint:
+     *
+     * text:
+     *   type: markdown
+     *   query:
+     *     albums: site.find('albums')
+     *   info:
+     *     albums: "{{ page.title.uppercase }}"
+     */
+
+      /**
+     * The button definition. This button just opens the dialog, when clicked.
+     */
+    get button() {
+      return {
+        icon: "document",
+        label: "Insert Album",
+        command: () => {
+          /* The pages endpoint should be set to the pattern /(:any)/pages 
+           * where :any is the name of your extension and the corresponding
+           * key in the blueprint query and info fields.
+           */
+          this.editor.emit("dialog", this, {
+            endpoint: this.input.endpoints.field + "/albums/pages",
+            multiple: false,
+            selected: [],
+          });
+        }
+      };
+    },
+    /**
+     * What the button is actually supposed to do, when the dialog’s form gets submitted
+     * In this case, we reuse the logic from the original pagelink button.
+     */
+    get command() {
+      return (selected) => {
+        if (this.isDisabled()) {
+          return;
+        }
+
+        if (!selected || !selected.length) {
+          return;
+        }
+
+        const page      = selected[0];
+        const selection = this.editor.getSelection();
+        const text      = selection.length > 0 ? selection : page.text || page.title;
+        const lang      = this.input.currentLanguage && !this.input.currentLanguage.default ? ` lang: ${this.input.currentLanguage.code}` : "";
+        const tag       = `(link: ${page.id} text: ${text}${lang})`;
+
+        this.editor.insert(tag);
+      };
+    },
+
+    /**
+     * Must be a unique identifier. Use the `toolbar` field property in your blueprints,
+     * to add this button to a Markdown field’s toolbar.
+     */
+    get name() {
+      return "albums";
+    },
+
+    /**
+     * Name of the dialog component. In this case, we reuse the native k-pages-dialog.
+     */
+    get dialog() {
+      return "k-pages-dialog";
+    }
+  });
+
+})();

--- a/extension-examples/custom-pagelink/index.js
+++ b/extension-examples/custom-pagelink/index.js
@@ -12,13 +12,14 @@
      *
      * text:
      *   type: markdown
-     *   query:
-     *     albums: site.find('albums')
-     *   info:
-     *     albums: "{{ page.title.uppercase }}"
+     *   buttons:
+     *     albums:
+     *       pages:
+     *         query: site.find('albums')
+     *         info: "{{ page.title.uppercase }}"
      */
 
-      /**
+    /**
      * The button definition. This button just opens the dialog, when clicked.
      */
     get button() {

--- a/fields/markdown.php
+++ b/fields/markdown.php
@@ -55,6 +55,10 @@ return [
             return $query;
         },
 
+        'info' => function ($info = null) {
+            return $info;
+        },
+
         'highlights' => function ($highlights = true) {
             return $highlights;
         },
@@ -127,14 +131,17 @@ return [
                 'pattern' => 'pages',
                 'method' => 'GET',
                 'action' => function () {
+                    $extension = get('extension', 'pagelink');
                     $field = $this->field();
                     $model = $field->model();
-                    $query = $field->query()['pagelink'] ?? false;
+                    $info = $field->info()[$extension] ?? false;
+                    $query = $field->query()[$extension] ?? false;
 
                     $params = [
                         'page'     => $this->requestQuery('page'),
                         'parent'   => $this->requestQuery('parent'),
                         'model'    => $model,
+                        'info'     => $info,
                         'query'    => $query,
                         'search'   => $this->requestQuery('search'),
                     ];

--- a/fields/markdown.php
+++ b/fields/markdown.php
@@ -128,10 +128,9 @@ return [
                 }
             ],
             [
-                'pattern' => 'pages',
+                'pattern' => ['pages', '(:any)/pages'],
                 'method' => 'GET',
-                'action' => function () {
-                    $extension = get('extension', 'pagelink');
+                'action' => function ($extension = 'pagelink') {
                     $field = $this->field();
                     $model = $field->model();
                     $info = $field->info()[$extension] ?? false;


### PR DESCRIPTION
This PR adds the ability to configure additional options for the builtin `pagelink` button, via a new top-level `pages` property (mirroring the top-level `files` and `uploads` options). This new property supports more options than just `query`, including `info` and `text`.

```yaml
text:
  type: markdown
  pages:
    query: site.index
    info: "{{ page.tags }}"
  buttons:
    - pagelink
```

Additionally, this PR adds the ability for extensions to support their own `pages`, `files`, and `uploads` properties. For example, you could add multiple extensions to add multiple buttons to link different types of pages.

```yaml
text:
  type: markdown
  files:
    […]
  pages:
    […]
  buttons:
    pagelink:
      pages:
        query: site.index
        info: "{{ page.tags }}"
    albums:
      pages:
        query: site.find('albums')
        info: "{{ page.tags }}"
 ```

To implement this feature I added an optional route pattern for the `markdown` field's `pages`, `files`, and `uploads` routes: `/(:any)/pages`, `/(:any)/files`, and `/(:any)/uploads` where `(:any)` is the name of the extension and the corresponding key in the blueprint buttons property.

Extensions can open a pages picker, for example, that reads the appropriate `query` and `info` properties by setting the endpoint appropriately:

```js
this.editor.emit("dialog", this, {
  endpoint: this.input.endpoints.field + "/albums/pages",
  multiple: false,
  selected: [],
});
```

I also updated the README and added an example of a custom pagelink extension.

*Note: This PR also soft-deprecates the existing `query` option (by removing it from the documentation, but still reading the value as a fallback)*